### PR TITLE
Fix insecure password storage and move encryption key to env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Environment variables for Campus Hive
+ENCRYPTION_KEY=ChangeThisKey

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.class
+.env

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ The **Campus Hive** project uses H2 for data persistence:
 - After setting up the JavaFX SDK and H2 database, navigate to the main application file in the **src/application** directory.
 - Run the application from your IDE.
 
+### 5. Configure Environment Variables
+- Create a `.env` file (see `.env.example`) and define `ENCRYPTION_KEY` with the key used for article encryption.
+
 ---
 
 ## Project Structure

--- a/src/application/EncryptionManager.java
+++ b/src/application/EncryptionManager.java
@@ -20,6 +20,11 @@ import java.util.Base64;
 
 public class EncryptionManager {
 
+    public static String getKey() {
+        String key = System.getenv("ENCRYPTION_KEY");
+        return key != null ? key : "CustomKey123";
+    }
+
     /**
      * Encrypts the given data using a custom XOR-based encryption algorithm.
      *
@@ -103,14 +108,14 @@ public class EncryptionManager {
     public static void main(String[] args) {
         try {
             // Example usage
-            String key = "CustomKey123"; // Custom encryption key
+            String key = getKey();
             String originalText = "Hello, Custom Encryption!";
 
             System.out.println("Original Text: " + originalText);
 
             // Encrypt the data
             String encryptedBody = "BhsQBhYdPwwWX39SLRQUER1DLwAaQ0tDN10RGwsU"; // Example
-            String decryptedBody = EncryptionManager.decrypt(encryptedBody, "CustomKey123");
+            String decryptedBody = EncryptionManager.decrypt(encryptedBody, key);
             System.out.println("Decrypted Body: " + decryptedBody);
             
             String encryptedText = encrypt(originalText, key);

--- a/src/application/EncryptionTest.java
+++ b/src/application/EncryptionTest.java
@@ -27,7 +27,7 @@ class EncryptionTest {
     void testEncryptDecrypt() {
         // Arrange
         String originalText = "Hello, Custom Encryption!";
-        String key = "CustomKey123";
+        String key = EncryptionManager.getKey();
 
         // Encrypt the original text
         String encryptedText = EncryptionManager.encrypt(originalText, key);
@@ -49,7 +49,7 @@ class EncryptionTest {
         String invalidBase64 = "InvalidBase64==";
 
         IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
-            EncryptionManager.decrypt(invalidBase64, "CustomKey123");
+            EncryptionManager.decrypt(invalidBase64, EncryptionManager.getKey());
         });
 
         // Check the exception message
@@ -61,7 +61,7 @@ class EncryptionTest {
     void testDecryptWithIncorrectKey() {
         // Arrange
         String originalText = "Hello, Custom Encryption!";
-        String key = "CustomKey123";
+        String key = EncryptionManager.getKey();
         String incorrectKey = "WrongKey456";
 
         // Encrypt the original text with the correct key

--- a/src/application/H2Database.java
+++ b/src/application/H2Database.java
@@ -19,6 +19,8 @@ import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import application.PasswordUtils;
+
 public class H2Database {
 
     private static final String DB_URL = "jdbc:h2:./data/users/userdb";
@@ -54,7 +56,8 @@ public class H2Database {
              PreparedStatement preparedStatement = connection.prepareStatement(insertUserQuery)) {
 
             preparedStatement.setString(1, username);
-            preparedStatement.setString(2, password);
+            String hashed = PasswordUtils.hashPassword(password);
+            preparedStatement.setString(2, hashed);
             preparedStatement.setString(3, firstName);
             preparedStatement.setString(4, middleName);
             preparedStatement.setString(5, lastName);
@@ -202,10 +205,11 @@ public class H2Database {
         try (Connection connection = DriverManager.getConnection(DB_URL, USER, PASSWORD);
              PreparedStatement preparedStatement = connection.prepareStatement(updatePasswordQuery)) {
 
-            preparedStatement.setString(1, newPassword);
+            String hashed = PasswordUtils.hashPassword(newPassword);
+            preparedStatement.setString(1, hashed);
             preparedStatement.setString(2, email);
             int rowsUpdated = preparedStatement.executeUpdate();
-            return rowsUpdated > 0; 
+            return rowsUpdated > 0;
         }
     }
     
@@ -262,18 +266,21 @@ public class H2Database {
     }
 
     public static String[] checkLogin(String username, String password) throws SQLException {
-        String selectQuery = "SELECT * FROM users WHERE username = ? AND password = ?";
+        String selectQuery = "SELECT * FROM users WHERE username = ?";
         try (Connection connection = DriverManager.getConnection(DB_URL, USER, PASSWORD);
              PreparedStatement preparedStatement = connection.prepareStatement(selectQuery)) {
 
             preparedStatement.setString(1, username);
-            preparedStatement.setString(2, password);
             ResultSet resultSet = preparedStatement.executeQuery();
 
             if (resultSet.next()) {
+                String stored = resultSet.getString("password");
+                if (!PasswordUtils.verifyPassword(password, stored)) {
+                    return null;
+                }
                 String[] user = {
                         resultSet.getString("username"),
-                        resultSet.getString("password"),
+                        stored,
                         resultSet.getString("firstName"),
                         resultSet.getString("middleName"),
                         resultSet.getString("lastName"),
@@ -283,7 +290,7 @@ public class H2Database {
                 };
                 return user;
             } else {
-                return null; 
+                return null;
             }
         }
         

--- a/src/application/HelpArticlePage.java
+++ b/src/application/HelpArticlePage.java
@@ -520,7 +520,7 @@ public class HelpArticlePage implements Initializable {
 
             // Encrypt if sensitive
             if (article.isSensitive()) {
-                String encryptedBody = EncryptionManager.encrypt(article.getBody(), "CustomKey123");
+                String encryptedBody = EncryptionManager.encrypt(article.getBody(), EncryptionManager.getKey());
                 System.out.println("Encrypted Body Before Saving: " + encryptedBody);
                 article.setBody(encryptedBody); // Save the encrypted body
             }
@@ -586,8 +586,8 @@ public class HelpArticlePage implements Initializable {
 	                // Decrypt if sensitive	
 	                if (isSensitive && body != null) {
 	                    System.out.println("Encrypted Body After Loading: " + body);
-	                    try {
-	                        body = EncryptionManager.decrypt(body, "CustomKey123");
+                            try {
+                                body = EncryptionManager.decrypt(body, EncryptionManager.getKey());
 	                    } catch (Exception ex) {
 	                        System.err.println(id + ex.getMessage());
 	                    }
@@ -595,7 +595,7 @@ public class HelpArticlePage implements Initializable {
 	
                 }
                 else {
-                	if(EncryptionManager.isEncrypted(body, "CustomKey123")) {
+                        if(EncryptionManager.isEncrypted(body, EncryptionManager.getKey())) {
                 		body = "This article is encrypted!";
                 	}
                 }

--- a/src/application/HelpArticleView.java
+++ b/src/application/HelpArticleView.java
@@ -134,7 +134,7 @@ public class HelpArticleView {
                 if (isSensitive && body != null) {
                     System.out.println("Encrypted Body Before Decryption: " + body);
                     try {
-                        body = EncryptionManager.decrypt(body, "CustomKey123");
+                        body = EncryptionManager.decrypt(body, EncryptionManager.getKey());
                         System.out.println("Decrypted Body: " + body);
                     } catch (Exception ex) {
                         System.err.println(article.getId() + " - Decryption failed: " + ex.getMessage());

--- a/src/application/PasswordUtils.java
+++ b/src/application/PasswordUtils.java
@@ -1,0 +1,48 @@
+package application;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+public class PasswordUtils {
+    private static final int ITERATIONS = 65536;
+    private static final int KEY_LENGTH = 256;
+
+    public static String hashPassword(String password) {
+        byte[] salt = new byte[16];
+        new SecureRandom().nextBytes(salt);
+        byte[] hash = pbkdf2(password.toCharArray(), salt);
+        return Base64.getEncoder().encodeToString(salt) + ":" + Base64.getEncoder().encodeToString(hash);
+    }
+
+    public static boolean verifyPassword(String password, String stored) {
+        if (stored == null || !stored.contains(":")) {
+            return false;
+        }
+        String[] parts = stored.split(":");
+        byte[] salt = Base64.getDecoder().decode(parts[0]);
+        byte[] hash = pbkdf2(password.toCharArray(), salt);
+        byte[] storedHash = Base64.getDecoder().decode(parts[1]);
+        if (hash.length != storedHash.length) return false;
+        for (int i = 0; i < hash.length; i++) {
+            if (hash[i] != storedHash[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static byte[] pbkdf2(char[] password, byte[] salt) {
+        try {
+            PBEKeySpec spec = new PBEKeySpec(password, salt, ITERATIONS, KEY_LENGTH);
+            SecretKeyFactory skf = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+            return skf.generateSecret(spec).getEncoded();
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new RuntimeException("Error while hashing password", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add PasswordUtils for PBKDF2 hashing
- store and verify hashed passwords in `H2Database`
- read article encryption key from `ENCRYPTION_KEY` environment variable
- update help article classes and tests to use the env-based key
- document environment setup in README
- add `.env.example` and `.gitignore`

## Testing
- `javac -cp "lib/*" src/application/PasswordUtils.java src/application/H2Database.java src/application/EncryptionManager.java`
- ❌ `javac -cp "lib/*" src/application/PasswordUtils.java src/application/H2Database.java src/application/EncryptionManager.java src/application/HelpArticlePage.java src/application/HelpArticleView.java src/application/EncryptionTest.java` *(fails: package javafx.fxml does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68620798678c8331bb0e4cfed88ecdfc